### PR TITLE
First version of additive 2D resampler

### DIFF
--- a/src/JincRessize.h
+++ b/src/JincRessize.h
@@ -56,6 +56,9 @@ class JincResize : public GenericVideoFilter
     int64_t iWidth, iHeight;
     int64_t iWidthEl, iHeightEl;
 
+    bool avx512;
+    bool avx2;
+    bool sse41;
     
     template<typename T>
     void resize_plane_c(EWAPixelCoeff* coeff[3], PVideoFrame& src, PVideoFrame& dst, IScriptEnvironment* env);

--- a/src/JincRessize.h
+++ b/src/JincRessize.h
@@ -41,6 +41,22 @@ class JincResize : public GenericVideoFilter
     float peak;
     int threads_;
 
+    bool bAddProc;
+    unsigned char *g_pElImageBuffer;
+    float* g_pfImageBuffer = 0, * g_pfFilteredImageBuffer = 0;
+    int64_t SzFilteredImageBuffer;
+    float* pfEndOfFilteredImageBuffer;
+
+    float *g_pfKernel = 0;
+    float* g_pfKernelWeighted = 0;
+
+    int64_t iKernelSize;
+    int64_t iMul;
+    int64_t iTaps;
+    int64_t iWidth, iHeight;
+    int64_t iWidthEl, iHeightEl;
+
+    
     template<typename T>
     void resize_plane_c(EWAPixelCoeff* coeff[3], PVideoFrame& src, PVideoFrame& dst, IScriptEnvironment* env);
     template <typename T>
@@ -52,6 +68,9 @@ class JincResize : public GenericVideoFilter
 
     void(JincResize::*process_frame)(EWAPixelCoeff**, PVideoFrame&, PVideoFrame&, IScriptEnvironment*);
 
+    void fill2DKernel(void);
+    void KernelProc(unsigned char *src, int iSrcStride, int iInpWidth, int iInpHeight, unsigned char *dst, int iDstStride);
+
 public:
     JincResize(PClip _child, int target_width, int target_height, double crop_left, double crop_top, double crop_width, double crop_height, int quant_x, int quant_y, int tap, double blur, int threads, int opt, IScriptEnvironment* env);
     PVideoFrame __stdcall GetFrame(int n, IScriptEnvironment* env);
@@ -60,6 +79,7 @@ public:
         return cachehints == CACHE_GET_MTMODE ? MT_MULTI_INSTANCE : 0;
     }
     ~JincResize();
+    
 };
 
 class Arguments


### PR DESCRIPTION
Finally some demo of additive 2D resampler integrated into real Avisynth plugin. It supports planar input colorspaces with equal or different sizes of planes (i.e. 4:4:4 to 4:2:0). It currently have only C implemented of additive processing loop and also looks MSVC2019 do not unroll loop or attempt to SIMD it. Unfortunately OpenMP for main processing loop do not starts well with x64 version of binary though works good in x86 2D_resampler separtate project. The pointers are local for rows but if enabling >1 thread it looks pointers are damaged for unknown reason. May be it syntax must be fixed for x64 OpenMP compiling. Intel C++ compiler produces working MT binary. For speed it looks slower in compare with current JincResize processing at low sizes of frames and up to 3 times faster at large frame sizes - like upsize 3000x2000 2x with taps=10. Also start time of creating small kernel instead of large ful-frame array of coefficients is also significally smaller. Also it require less memory for processing. It currently uses additive processing only on upsizing on equal integer value (like 2,3,4,etc). It have workaround for edges but still not for corners of buffer - so corners may suffer of ringing. May be in futire versions corner of El buffer must be filled with duplicated corner sample of input buffer or may be mirrored diagonally of corner part of input buffer.