### PR TITLE
4 planes processing and only 1 coeff_table for all planes init

### DIFF
--- a/src/JincRessize.h
+++ b/src/JincRessize.h
@@ -5,7 +5,7 @@
 #include <execution>
 
 #include "avisynth.h"
-#include "avs/minmax.h"
+#include "avs\minmax.h"
 
 struct EWAPixelCoeffMeta
 {
@@ -39,10 +39,11 @@ class JincResize : public GenericVideoFilter
 {
     std::string cplace;
     Lut* init_lut;
-    EWAPixelCoeff* out[3];
+    EWAPixelCoeff* out[4];
     int planecount;
     bool has_at_least_v8;
     float peak;
+	bool bAllPlanesEqual;
 
     template<typename T, int thr>
     void resize_plane_c(PVideoFrame& src, PVideoFrame& dst, IScriptEnvironment* env);


### PR DESCRIPTION
If all planes are equal (4:4:4 or RGB) - init only one copy of coeff_table and reuse for all planes to save RAM and speedup startup.

Also added processing up to 4 planes (including alpha if present).